### PR TITLE
feat: failed attempt to add git message template

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,4 +1,0 @@
-Subject line (try to keep under 50 characters)
-
-Multi-line description of commit, feel free to be detailed. Each line
-in your description should though wrap at the 72nd mark. 

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,4 @@
+Subject line (try to keep under 50 characters)
+
+Multi-line description of commit, feel free to be detailed. Each line
+in your description should though wrap at the 72nd mark. 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ The frontend was built with React and the styling was created with styled-compon
 
 ## View it live
 
+Link to be added when project is ready for go:live


### PR DESCRIPTION
I attempted to add the ~/.gitmessage.txt as described on https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration. This did not work however, as I got a conflict with COMMIT_EDITMSG  when I tried to just commit with git commit. 

I have added notes on how to write a great commit message to my dev notes in Notion instead.

This pull request therefore just contains a small update to the readme file that I did when testing out the new feature. 