### PR TITLE
feat(backend): add listEndpoints

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -98,9 +98,10 @@ const authenticateUser = async (req, res, next) => {
 
 // Start defining your routes here
 app.get('/', (req, res) => {
-	res.send(
-		"Welcome to Molbimiens skafferi API - by Maria Sjögren (https://github.com/molbimien/). See full documentation here 👉 https://github.com/molbimien/final-project-molbimien-recipes/blob/main/Documentation.md")
-			// listEndpoints(app),
+	res.send({
+		"Welcome to Molbimiens skafferi API - by Maria Sjögren (https://github.com/molbimien/). See full documentation here 👉 https://github.com/molbimien/final-project-molbimien-recipes/blob/main/Documentation.md":
+		listEndpoints(app),
+	})
 })
 
 // endpoint to get all recipes


### PR DESCRIPTION
As described here: https://dev.to/lawrence_eagles/causes-of-heroku-h10-app-crashed-error-and-how-to-solve-them-3jnl

I detected that I had failed to set the required environment variable. Adding the connection string to MongoDB in Heruko resolved the issue and this pull request adds back the listEndpoints feature. 